### PR TITLE
Wek fix return null statt 0 wenn int in result set null wäre

### DIFF
--- a/aero.minova.core.application.system.service/src/main/java/aero/minova/core/application/system/controller/SqlProcedureController.java
+++ b/aero.minova.core.application.system.service/src/main/java/aero/minova/core/application/system/controller/SqlProcedureController.java
@@ -330,8 +330,10 @@ public class SqlProcedureController {
 									outputValues.addValue(inputTable.getRows().get(0).getValues().get(i));
 								}
 							});
-					int securityTokenInColumn = securityService.findSecurityTokenColumn(inputTable);
-
+					int securityTokenInColumn = -1;
+					if (!userSecurityTokensToBeChecked.isEmpty()) {
+						securityTokenInColumn = securityService.findSecurityTokenColumn(inputTable);
+					}
 					Row resultRow = new Row();
 					if (securityService.isRowAccessValid(userSecurityTokensToBeChecked, outputValues, securityTokenInColumn)) {
 						resultRow = outputValues;


### PR DESCRIPTION
Es ist aufgefallen, dass Int und Double Datentypen als 0 zurück gegeben werden, wenn deren "wahrer Wert" in der Datenbank eigentlich NULL ist.
0 ist definitiv etwas anderes als NULL und wird in Zukunft mit Sicherheit Fehler herbei führen.

Früher wurde das von seiten WFC insofern kompensiert, dass ,wenn ein INT mit 0 kam, es im WFC auf NULL gesetzt wurde, aber das waren immer nur Lookups, bei welchen es klar war, dass es keinen KeyLong 0 geben kann.
Jetzt werden aber "echte" Int-Felder benötigt, die zwischen NULL und natürlichen Zahlen unterscheiden können.

Dazu gibt es noch den Mini-Fix, damit bei den OutputParametern nicht jedes Mal auf die SecurityToken-Spalte geprüft wird, sondern nur wenn benötigt.